### PR TITLE
Sensemaker Bridging For Resource Resolving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sensemaker_bridge"
+version = "0.0.1"
+dependencies = [
+ "hdk",
+]
+
+[[package]]
+name = "sensemaker_bridge_zome"
+version = "0.0.1"
+dependencies = [
+ "sensemaker_bridge",
+]
+
+[[package]]
 name = "sensemaker_integrity"
 version = "0.0.1"
 dependencies = [

--- a/client/src/applet.ts
+++ b/client/src/applet.ts
@@ -55,3 +55,8 @@ export interface WidgetRegistry {
         assess: typeof ConcreteAssessDimensionWidget,
     }
 }
+
+export interface FetchProviderResourceInput {
+    resource_eh: EntryHash,
+    resource_def_eh: EntryHash,
+}

--- a/client/src/applet.ts
+++ b/client/src/applet.ts
@@ -1,4 +1,4 @@
-import { EntryHash } from "@holochain/client";
+import { DnaHash, EntryHash } from "@holochain/client";
 import { ConfigCulturalContext } from "./culturalContext";
 import { ConfigDimension } from "./dimension";
 import { ConfigMethod } from "./method";
@@ -59,4 +59,6 @@ export interface WidgetRegistry {
 export interface FetchProviderResourceInput {
     resource_eh: EntryHash,
     resource_def_eh: EntryHash,
+    optional_role_name: string | null,
+    optional_dna_hash: DnaHash | null,
 }

--- a/client/src/sensemakerService.ts
+++ b/client/src/sensemakerService.ts
@@ -1,5 +1,5 @@
 import { AgentPubKey, AppAgentCallZomeRequest, AppAgentClient, EntryHash, EntryHashB64, Record as HolochainRecord, RoleName } from '@holochain/client';
-import { AppletConfig, AppletConfigInput, Assessment, ComputeContextInput, CreateAppletConfigInput, CreateAssessmentInput, CulturalContext, Dimension, GetAssessmentsForResourceInput, Method, ResourceDef, RunMethodInput } from './index';
+import { AppletConfig, AppletConfigInput, Assessment, ComputeContextInput, CreateAppletConfigInput, CreateAssessmentInput, CulturalContext, Dimension, FetchProviderResourceInput, GetAssessmentsForResourceInput, Method, ResourceDef, RunMethodInput } from './index';
 import { Option } from './utils';
 
 export class SensemakerService {
@@ -63,6 +63,10 @@ export class SensemakerService {
 
   async registerApplet(appletConfig: CreateAppletConfigInput): Promise<AppletConfig> {
     return this.callZome('register_applet', appletConfig);
+  }
+
+  async fetchProviderResource(fetchProviderResourceInput: FetchProviderResourceInput): Promise<Option<HolochainRecord>> {
+    return this.callZome('fetch_provider_resource', fetchProviderResourceInput);
   }
 
   private callZome(fn_name: string, payload: any) {

--- a/client/src/sensemakerStore.ts
+++ b/client/src/sensemakerStore.ts
@@ -1,4 +1,4 @@
-import { AgentPubKey, AppAgentClient, AppSignal, encodeHashToBase64, EntryHash, EntryHashB64, Record as HolochainRecord, RoleName } from '@holochain/client';
+import { AgentPubKey, AppAgentClient, AppSignal, encodeHashToBase64, EntryHash, EntryHashB64, Record as HolochainRecord, RoleName, DnaHash } from '@holochain/client';
 import { SensemakerService } from './sensemakerService';
 import { AppletConfig, Assessment, ComputeContextInput, ConcreteAssessDimensionWidget, ConcreteDisplayDimensionWidget, CreateAppletConfigInput, CreateAssessmentInput, CulturalContext, Dimension, GetAssessmentsForResourceInput, Method, ResourceDef, RunMethodInput, SignalPayload, WidgetMappingConfig, WidgetRegistry } from './index';
 import { derived, Writable, writable } from 'svelte/store';
@@ -261,8 +261,8 @@ export class SensemakerStore {
     )
   }
 
-  async fetchProviderResource(resourceEh: EntryHash, resourceDefEh: EntryHash): Promise<Option<HolochainRecord>> {
-    return await this.service.fetchProviderResource({ resource_eh: resourceEh, resource_def_eh: resourceDefEh });
+  async fetchProviderResource(resourceEh: EntryHash, resourceDefEh: EntryHash, roleName?: string, dnaHash?: DnaHash): Promise<Option<HolochainRecord>> {
+    return await this.service.fetchProviderResource({ resource_eh: resourceEh, resource_def_eh: resourceDefEh, optional_role_name: roleName ? roleName : null, optional_dna_hash: dnaHash ? dnaHash : null });
   }
 }
 

--- a/client/src/sensemakerStore.ts
+++ b/client/src/sensemakerStore.ts
@@ -260,6 +260,10 @@ export class SensemakerStore {
       }
     )
   }
+
+  async fetchProviderResource(resourceEh: EntryHash, resourceDefEh: EntryHash): Promise<Option<HolochainRecord>> {
+    return await this.service.fetchProviderResource({ resource_eh: resourceEh, resource_def_eh: resourceDefEh });
+  }
 }
 
 export const sensemakerStoreContext = createContext<SensemakerStore>(

--- a/dnas/sensemaker/zomes/coordinator/sensemaker/src/applet.rs
+++ b/dnas/sensemaker/zomes/coordinator/sensemaker/src/applet.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use hdk::prelude::*;
+use holo_hash::DnaHash;
 use sensemaker_integrity::{
     AppletConfig, AppletConfigInput, CulturalContext, Dimension, EntryTypes, LinkTypes, Method,
     ResourceDef,
@@ -153,6 +154,8 @@ pub fn create_entries_from_applet_config(
 pub struct FetchProviderResourceInput {
     pub resource_eh: EntryHash,
     pub resource_def_eh: EntryHash,
+    pub optional_role_name: Option<String>,
+    pub optional_dna_hash: Option<DnaHash>,
 }
 
 #[hdk_extern]
@@ -160,7 +163,9 @@ pub fn fetch_provider_resource(
     FetchProviderResourceInput {
         resource_eh,
         resource_def_eh,
+        optional_role_name,
+        optional_dna_hash,
     }: FetchProviderResourceInput
 ) -> ExternResult<Option<Record>> {
-    fetch_provider_resource_inner(resource_eh, resource_def_eh)
+    fetch_provider_resource_inner(resource_eh, resource_def_eh, optional_role_name, optional_dna_hash)
 }

--- a/dnas/sensemaker/zomes/coordinator/sensemaker/src/applet.rs
+++ b/dnas/sensemaker/zomes/coordinator/sensemaker/src/applet.rs
@@ -8,7 +8,7 @@ use sensemaker_integrity::{
 
 use crate::{
     create_cultural_context, create_dimension, create_method, create_range, create_resource_def,
-    utils::entry_from_record,
+    utils::{entry_from_record, fetch_provider_resource_inner},
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -147,4 +147,20 @@ pub fn create_entries_from_applet_config(
         })
         .collect::<ExternResult<Vec<ActionHash>>>()?;
     Ok((applet_config, applet_config_eh))
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct FetchProviderResourceInput {
+    pub resource_eh: EntryHash,
+    pub resource_def_eh: EntryHash,
+}
+
+#[hdk_extern]
+pub fn fetch_provider_resource(
+    FetchProviderResourceInput {
+        resource_eh,
+        resource_def_eh,
+    }: FetchProviderResourceInput
+) -> ExternResult<Option<Record>> {
+    fetch_provider_resource_inner(resource_eh, resource_def_eh)
 }

--- a/dnas/sensemaker/zomes/coordinator/sensemaker/src/assessment.rs
+++ b/dnas/sensemaker/zomes/coordinator/sensemaker/src/assessment.rs
@@ -114,7 +114,7 @@ pub fn get_all_assessments(_:()) -> ExternResult<Vec<AssessmentWithDimensionAndR
                         None => None
                     };
                     // attempt a bridge call to the provider zome to get the resource
-                    let resource = fetch_provider_resource_inner(assessment.resource_eh.clone(), assessment.resource_def_eh.clone())?;
+                    let resource = fetch_provider_resource_inner(assessment.resource_eh.clone(), assessment.resource_def_eh.clone(), None, None)?;
                     Ok(Some(AssessmentWithDimensionAndResource {
                         assessment,
                         dimension,

--- a/dnas/sensemaker/zomes/coordinator/sensemaker/src/assessment.rs
+++ b/dnas/sensemaker/zomes/coordinator/sensemaker/src/assessment.rs
@@ -13,7 +13,7 @@ use crate::agent::get_all_agents;
 use crate::get_dimension;
 use crate::signals::Signal;
 use crate::utils::entry_from_record;
-use crate::utils::fetch_provider_resource;
+use crate::utils::fetch_provider_resource_inner;
 use crate::utils::flatten_btree_map;
 use crate::utils::get_assessments_for_resource_inner;
 
@@ -114,7 +114,7 @@ pub fn get_all_assessments(_:()) -> ExternResult<Vec<AssessmentWithDimensionAndR
                         None => None
                     };
                     // attempt a bridge call to the provider zome to get the resource
-                    let resource = fetch_provider_resource(assessment.resource_eh.clone(), assessment.resource_def_eh.clone())?;
+                    let resource = fetch_provider_resource_inner(assessment.resource_eh.clone(), assessment.resource_def_eh.clone())?;
                     Ok(Some(AssessmentWithDimensionAndResource {
                         assessment,
                         dimension,

--- a/dnas/sensemaker/zomes/coordinator/sensemaker/src/utils.rs
+++ b/dnas/sensemaker/zomes/coordinator/sensemaker/src/utils.rs
@@ -55,7 +55,7 @@ pub fn flatten_btree_map<K, V: Clone>(btree_map: BTreeMap<K, Vec<V>>) -> Vec<V> 
         .collect::<Vec<V>>()
 }
 
-pub fn fetch_provider_resource(
+pub fn fetch_provider_resource_inner(
     resource_eh: EntryHash,
     resource_def_eh: EntryHash,
 ) -> ExternResult<Option<Record>> {
@@ -73,7 +73,7 @@ pub fn fetch_provider_resource(
             if let Some(role_name) = applet_config.role_name {
                 let response = call(
                     CallTargetCell::OtherRole(role_name),
-                    ZomeName::from("test_provider"),
+                    ZomeName::from("sensemaker_bridge"),
                     "get_resource".into(),
                     None,
                     resource_eh,

--- a/dnas/sensemaker/zomes/integrity/sensemaker/src/applet.rs
+++ b/dnas/sensemaker/zomes/integrity/sensemaker/src/applet.rs
@@ -4,7 +4,7 @@ use hdi::prelude::*;
 
 use crate::{
     CulturalContext, Dimension, Method, OrderingKind, Program, Range, RangeValue, ResourceDef,
-    ThresholdKind,
+    ThresholdKind, resource_def::ResourceDefSource,
 };
 
 #[hdk_entry_helper]
@@ -12,7 +12,7 @@ use crate::{
 pub struct AppletConfig {
     pub name: String,
     pub ranges: BTreeMap<String, EntryHash>,
-    pub role_name: Option<String>,
+    pub happ_info: BTreeMap<String, DnaHash>, // mapping role names to dna hashes of the applet happ
     pub dimensions: BTreeMap<String, EntryHash>,
     // the base_type field in ResourceDef needs to be bridged call
     pub resource_defs: BTreeMap<String, EntryHash>,
@@ -98,6 +98,7 @@ pub struct ConfigResourceDef {
     pub name: String,
     pub base_types: Vec<AppEntryDef>,
     pub dimensions: Vec<ConfigDimension>,
+    pub source: ResourceDefSource,
 }
 
 impl ConfigResourceDef {

--- a/dnas/sensemaker/zomes/integrity/sensemaker/src/lib.rs
+++ b/dnas/sensemaker/zomes/integrity/sensemaker/src/lib.rs
@@ -17,7 +17,7 @@ pub use dimension::Dimension;
 pub use method::{DataSet, Method, Program};
 pub use properties::{Properties, SensemakerConfig};
 pub use range::{Range, RangeValue};
-pub use resource_def::ResourceDef;
+pub use resource_def::{ResourceDef, ResourceDefSource};
 
 #[hdk_entry_defs]
 #[unit_enum(UnitEntryTypes)]
@@ -45,6 +45,7 @@ pub enum LinkTypes {
     AppletName,
     AppletConfig,
     ResourceDefEhToAppletConfig,
+    ResourceDefEhToProviderDnaHash,
     AllAgentsPath,
 }
 

--- a/dnas/sensemaker/zomes/integrity/sensemaker/src/resource_def.rs
+++ b/dnas/sensemaker/zomes/integrity/sensemaker/src/resource_def.rs
@@ -8,6 +8,13 @@ pub struct ResourceDef {
     pub name: String,
     pub base_types: Vec<AppEntryDef>,
     pub dimension_ehs: Vec<EntryHash>,
+    pub source: ResourceDefSource,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ResourceDefSource {
+    Dna(DnaHash),
+    // can add other source types here, like a website, IPFS, blockchain, etc.
 }
 
 impl TryFrom<ConfigResourceDef> for ResourceDef {
@@ -25,6 +32,7 @@ impl TryFrom<ConfigResourceDef> for ResourceDef {
             name: value.name,
             base_types: value.base_types,
             dimension_ehs,
+            source: value.source,
         };
         Ok(resource_def)
     }

--- a/dnas/test_provider/workdir/dna.yaml
+++ b/dnas/test_provider/workdir/dna.yaml
@@ -15,4 +15,5 @@ coordinator:
       bundled: ../../../target/wasm32-unknown-unknown/release/test_provider.wasm
       dependencies:
         - name: test_provider_integrity
-
+    - name: sensemaker_bridge
+      bundled: ../../../target/wasm32-unknown-unknown/release/sensemaker_bridge_zome.wasm

--- a/dnas/test_provider/zomes/coordinator/sensemaker_bridge/Cargo.toml
+++ b/dnas/test_provider/zomes/coordinator/sensemaker_bridge/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2021"
+name = "sensemaker_bridge_zome"
+version = "0.0.1"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "sensemaker_bridge_zome"
+
+[dependencies]
+sensemaker_bridge = { path = "../../../../../../sensemaker-bridge/coordinator" }

--- a/dnas/test_provider/zomes/coordinator/sensemaker_bridge/src/lib.rs
+++ b/dnas/test_provider/zomes/coordinator/sensemaker_bridge/src/lib.rs
@@ -1,0 +1,1 @@
+extern crate sensemaker_bridge;

--- a/dnas/test_provider/zomes/coordinator/test_provider/src/post.rs
+++ b/dnas/test_provider/zomes/coordinator/test_provider/src/post.rs
@@ -3,11 +3,6 @@ use test_provider_integrity::EntryTypes;
 use test_provider_integrity::Post;
 
 #[hdk_extern]
-pub fn get_resource(entry_hash: EntryHash) -> ExternResult<Option<Record>> {
-    get(entry_hash, GetOptions::default())
-}
-
-#[hdk_extern]
 pub fn get_post(entry_hash: EntryHash) -> ExternResult<Option<Record>> {
     get(entry_hash, GetOptions::default())
 }

--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
       },
       "locked": {
         "dir": "versions/0_1",
-        "lastModified": 1684835111,
-        "narHash": "sha256-EMy/jE4xc3WXwKMo5yOUtWUMfqVX2Czm5/2DFhFOBls=",
+        "lastModified": 1685392562,
+        "narHash": "sha256-LyVzqnVPa9bX+Bj3lz1PjowjghAuHEbXqqGMM5gG1+0=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "06523233760d1bc458f1e94874334e7b02db4bbc",
+        "rev": "aacf793e09ef15f6ad535c2f83202029aa974f20",
         "type": "github"
       },
       "original": {

--- a/tests/src/sensemaker_dna/sensemaker/dashboard.ts
+++ b/tests/src/sensemaker_dna/sensemaker/dashboard.ts
@@ -302,6 +302,21 @@ export default () => {
         t.ok(allAssessedPosts.find((p) => JSON.stringify(p) === JSON.stringify(createPost2)))
         t.ok(allAssessedPosts.find((p) => JSON.stringify(p) === JSON.stringify(createPost3)))
 
+
+        const resourceFromProvider: Record = await callZomeAlice(
+          "sensemaker",
+          "fetch_provider_resource",
+          {
+            resource_eh: createPostEntryHash,
+            resource_def_eh: appletConfig.resource_defs["angryPost"],
+          },
+          true
+        );
+        console.log('resource from provider', resourceFromProvider);
+        t.ok(resourceFromProvider);
+        t.deepEqual(decode((resourceFromProvider.entry as any).Present.entry) as any, createPost);
+
+
       } catch (e) {
         console.log(e);
         t.ok(null);

--- a/tests/src/sensemaker_dna/sensemaker/dashboard.ts
+++ b/tests/src/sensemaker_dna/sensemaker/dashboard.ts
@@ -8,7 +8,7 @@ import {
   cleanAllConductors,
 } from "@holochain/tryorama";
 import { decode } from "@msgpack/msgpack";
-import { AppletConfig, Assessment, AssessmentWithDimensionAndResource, CreateAppletConfigInput, CreateAssessmentInput, Method, RangeValueInteger } from "@neighbourhoods/client";
+import { AppletConfig, Assessment, AssessmentWithDimensionAndResource, CreateAppletConfigInput, CreateAssessmentInput, FetchProviderResourceInput, Method, RangeValueInteger } from "@neighbourhoods/client";
 import { ok } from "assert";
 import pkg from "tape-promise/tape";
 import { installAgent, sampleAppletConfig } from "../../utils";
@@ -302,14 +302,15 @@ export default () => {
         t.ok(allAssessedPosts.find((p) => JSON.stringify(p) === JSON.stringify(createPost2)))
         t.ok(allAssessedPosts.find((p) => JSON.stringify(p) === JSON.stringify(createPost3)))
 
-
+        const fetchProviderResourceInput: FetchProviderResourceInput = {
+          resource_eh: createPostEntryHash,
+          resource_def_eh: appletConfig.resource_defs["angryPost"],
+          optional_role_name: null,
+        };
         const resourceFromProvider: Record = await callZomeAlice(
           "sensemaker",
           "fetch_provider_resource",
-          {
-            resource_eh: createPostEntryHash,
-            resource_def_eh: appletConfig.resource_defs["angryPost"],
-          },
+          fetchProviderResourceInput,
           true
         );
         console.log('resource from provider', resourceFromProvider);


### PR DESCRIPTION
This PR aims to add the ability for provider DNAs to register themselves with the sensemaker so that bridge calls can be made. To facilitate standardized bridge calls, a [zome](https://github.com/neighbour-hoods/sensemaker-bridge-zome) should be added to any provider DNA that wants to enable bridging with the sensemaker.