### PR TITLE
pin lair keystore version URL

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
       url = "github:holochain/holochain";
       inputs.versions.url = "github:holochain/holochain/?dir=versions/0_1";
       inputs.holochain.url = "github:holochain/holochain/holochain-0.1.3";
+      inputs.lair.url = "github:holochain/lair/lair_keystore-v0.2.3";
     };
   };
 


### PR DESCRIPTION
Resolves #80 

But probably also points to the fact that our Holochain env for the Sensemaker is way outdated, and quite possibly incompatible with recent versions of the Launcher DNAs and / or Holochain Launcher?